### PR TITLE
Fix reward timing in Q-learning

### DIFF
--- a/myproject/agent.py
+++ b/myproject/agent.py
@@ -208,14 +208,15 @@ class QLearningAgent:
         
         return selected_price
     
-    def learn(self, next_opponent_prices: np.ndarray):
-        """Update Q-table based on observed transition."""
+    def learn(self, rewards: np.ndarray, next_opponent_prices: np.ndarray):
+        """Update Q-table using reward from the last action."""
         if hasattr(self, 'last_state'):
             next_state = self._encode_state(next_opponent_prices)
+            reward = rewards[self.agent_id]
             self.update_q_table(
                 self.last_state,
-                self.last_action, 
-                self.last_reward,
+                self.last_action,
+                reward,
                 next_state
             )
     
@@ -240,8 +241,8 @@ class QLearningAgent:
     def update(self, observation, actions, rewards):
         """Update agent for compatibility with existing interface."""
         # Update Q-table
-        self.learn(observation)
-        
+        self.learn(rewards, observation)
+
         # Update epsilon
         self.update_epsilon()
     

--- a/myproject/train.py
+++ b/myproject/train.py
@@ -95,24 +95,29 @@ def train_agents(
         env.reset()
         for agent in agents:
             agent.reset_episode()
-        
+
+        # Initial rewards from starting prices
+        prev_rewards = env.compute_profits(env.current_prices)
         episode_profits = []
-        
+
         # Inner loop: iterations within episode
         for iteration in range(iterations_per_episode):
             current_prices = env.current_prices.copy()
-            
-            # Agent actions
+
+            # Agent actions based on previous rewards
             new_prices = np.zeros(env.n_agents)
             for i, agent in enumerate(agents):
-                new_prices[i] = agent.step(current_prices, env.compute_profits(current_prices))
-            
-            # Environment step
+                new_prices[i] = agent.step(current_prices, prev_rewards)
+
+            # Environment step to obtain new rewards
             _, rewards, _, info = env.step(new_prices)
-            
-            # Agent learning updates
+
+            # Agent learning updates with rewards from this step
             for agent in agents:
-                agent.learn(new_prices)
+                agent.learn(rewards, new_prices)
+
+            # Update previous rewards
+            prev_rewards = rewards
             
             # Sample episode data
             if iteration % 250 == 0:


### PR DESCRIPTION
## Summary
- fix off-by-one reward usage in `QLearningAgent`
- pass current rewards into `learn` during training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866795031f48320b351fbe298a4ff65