### PR TITLE
Fix reward update logic

### DIFF
--- a/myproject/env.py
+++ b/myproject/env.py
@@ -91,8 +91,9 @@ class DemandEnvironment:
         return self.current_prices.copy(), rewards, done, info
     
     def reset(self) -> np.ndarray:
-        """Reset environment to initial state."""
-        self.current_prices = np.zeros(self.n_agents)
+        """Reset environment to the Nash equilibrium state."""
+        nash_price = self.compute_nash_equilibrium()
+        self.current_prices = np.full(self.n_agents, nash_price)
         self.episode_step = 0
         return self.current_prices.copy()
     

--- a/myproject/train.py
+++ b/myproject/train.py
@@ -101,18 +101,18 @@ def train_agents(
         # Inner loop: iterations within episode
         for iteration in range(iterations_per_episode):
             current_prices = env.current_prices.copy()
-            
+
             # Agent actions
             new_prices = np.zeros(env.n_agents)
             for i, agent in enumerate(agents):
-                new_prices[i] = agent.step(current_prices, env.compute_profits(current_prices))
-            
+                new_prices[i] = agent.step(current_prices)
+
             # Environment step
             _, rewards, _, info = env.step(new_prices)
-            
-            # Agent learning updates
-            for agent in agents:
-                agent.learn(new_prices)
+
+            # Agent learning updates with received rewards
+            for i, agent in enumerate(agents):
+                agent.learn(rewards[i], new_prices)
             
             # Sample episode data
             if iteration % 250 == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Complete Python implementation of Calvano et al. (2020) Q-learnin
 authors = [
     {name = "Yusei Nozawa", email = "yusei.nozawa@example.com"}
 ]
-readme = "README_COMPLETE.md"
+readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.8"
 keywords = ["economics", "q-learning", "algorithmic-pricing", "collusion", "replication"]


### PR DESCRIPTION
## Summary
- use reward from current iteration when updating Q-table
- start env reset at Nash price
- fix README path in `pyproject.toml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667966832883208e63bf79d7a58e41